### PR TITLE
add sourcemap to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /include
 *.tsbuildinfo
 flamework.build
+sourcemap.json


### PR DESCRIPTION
Saves adding a line if a user still intends to use luau lsp in the project (since it uses rojo sourcemaps).

I don't think there's a reason to commit sourcemaps to git, since they just create messy commits, but correct me if I'm wrong.