### PR TITLE
Updated Typescript version number to tilde-range on 5.2.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettier": "^2.3.2",
     "rbxts-transformer-flamework": "=1.0.0-beta.24",
     "roblox-ts": "^2.2.0",
-    "typescript": "^5.2.2"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
     "@flamework/components": "=1.0.0-beta.24",


### PR DESCRIPTION
From the discussion in the Roblox-TS discord [here](https://discord.com/channels/476080952636997633/498292664471388160/1182081754492829796), it appears that Typescript 5.3.* isn't yet supported by Flamework. After freshly pulling, using a non-npm package manager will attempt to pull TS 5.3.2. To avoid confusion, I've adjusted the typescript dependency to be a tilde-range on ~5.2.*